### PR TITLE
watch: Introduce `Watch::then_stream`

### DIFF
--- a/futures-watch/src/lib.rs
+++ b/futures-watch/src/lib.rs
@@ -101,9 +101,9 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 
 /// Uses a `Watch` to produce a `Stream` of mapped values.
-pub mod map_stream;
+pub mod then_stream;
 
-pub use map_stream::Map;
+pub use then_stream::Then;
 
 /// A future-aware cell that receives notifications when the inner value is
 /// changed.
@@ -283,8 +283,8 @@ impl<T> Watch<T> {
     }
 
     /// Convert this watch into a stream of values produced by an `M`-typed map function.
-    pub fn map_stream<M: Map<T>>(self, map: M) -> map_stream::MapStream<T, M> {
-        map_stream::MapStream::new(self, map)
+    pub fn then_stream<M: Then<T>>(self, then: M) -> then_stream::ThenStream<T, M> {
+        then_stream::ThenStream::new(self, then)
     }
 }
 

--- a/futures-watch/src/lib.rs
+++ b/futures-watch/src/lib.rs
@@ -88,6 +88,7 @@
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 extern crate fnv;
+#[macro_use]
 extern crate futures;
 
 use fnv::FnvHashMap;
@@ -98,6 +99,11 @@ use std::{mem, ops};
 use std::sync::{Arc, Weak, Mutex, RwLock, RwLockReadGuard};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
+
+/// Uses a `Watch` to produce a `Stream` of mapped values.
+pub mod map_stream;
+
+pub use map_stream::Map;
 
 /// A future-aware cell that receives notifications when the inner value is
 /// changed.
@@ -274,6 +280,11 @@ impl<T> Watch<T> {
     pub fn borrow(&self) -> Ref<T> {
         let inner = self.shared.value.read().unwrap();
         Ref { inner }
+    }
+
+    /// Convert this watch into a stream of values produced by an `M`-typed map function.
+    pub fn map_stream<M: Map<T>>(self, map: M) -> map_stream::MapStream<T, M> {
+        map_stream::MapStream::new(self, map)
     }
 }
 

--- a/futures-watch/src/lib.rs
+++ b/futures-watch/src/lib.rs
@@ -88,7 +88,6 @@
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 extern crate fnv;
-#[macro_use]
 extern crate futures;
 
 use fnv::FnvHashMap;

--- a/futures-watch/src/map_stream.rs
+++ b/futures-watch/src/map_stream.rs
@@ -1,0 +1,60 @@
+use futures::{Poll, Stream};
+
+/// Maps borrowed references to `T` into an `Item`.
+pub trait Map<T> {
+    /// The output type.
+    type Output;
+
+
+    /// What you get when Map fails.
+    type Error;
+
+    /// Produces a new Output value.
+    fn map(&mut self, t: &T) -> Result<Self::Output, Self::Error>;
+}
+
+/// Each time the underlying `Watch<T>` is updated, the stream maps over the most-recent
+/// value.
+#[derive(Debug)]
+pub struct MapStream<T, M: Map<T>> {
+    watch: super::Watch<T>,
+    map: M,
+}
+
+impl<T, M: Map<T>> MapStream<T, M> {
+    pub(crate) fn new(watch: super::Watch<T>, map: M) -> Self {
+        Self { watch, map }
+    }
+}
+
+impl<T, M: Map<T>> Stream for MapStream<T, M> {
+    type Item = <M as Map<T>>::Output;
+    type Error = Error<<M as Map<T>>::Error>;
+
+    fn poll(&mut self) -> Poll<Option<M::Output>, Self::Error> {
+        try_ready!(self.watch.poll().map_err(Error::WatchError));
+
+        let item = self.map.map(&*self.watch.borrow())
+            .map_err(Error::Map)?;
+
+        Ok(Some(item).into())
+    }
+}
+
+impl<T, M: Clone + Map<T>> Clone for MapStream<T, M> {
+    fn clone(&self) -> Self {
+        Self {
+            watch: self.watch.clone(),
+            map: self.map.clone(),
+        }
+    }
+}
+
+/// Errors produced by `MapStream::poll`.
+#[derive(Debug)]
+pub enum Error<E> {
+    /// An error mapping to a new value may be transient.
+    Map(E),
+    /// An error polling the underlying `Watch`. Probably fatal.
+    WatchError(super::WatchError),
+}

--- a/futures-watch/src/then_stream.rs
+++ b/futures-watch/src/then_stream.rs
@@ -11,7 +11,7 @@ pub trait Then<T> {
     type Error;
 
     /// Produces a new Output value.
-    fn then(&mut self, t: Result<&T,  WatchError>) -> Result<Self::Output, Self::Error>;
+    fn then(&mut self, t: Result<&T, WatchError>) -> Result<Self::Output, Self::Error>;
 }
 
 /// Each time the underlying `Watch<T>` is updated, the stream maps over the most-recent


### PR DESCRIPTION
It's not unusual to want to lazily derive values from a `Watch`. For
example, when watching a resource (file, directory, etc) for updates, an
application may want to rebind services, etc.

This change introduces `Watch::then_stream` that converts a `Watch` into
a stream of values derived from borrows on the Watch. The `Then` trait is
introduced so that `ThenStream` types may be named concretely.